### PR TITLE
make validatr conform to the html5 spec when form elements are disabled

### DIFF
--- a/src/js/validatr.js
+++ b/src/js/validatr.js
@@ -785,6 +785,19 @@
                 message: ''
             };
 
+        if ($element.prop('disabled')) {
+            check.disabled = true;
+        } else {
+            $element.parentsUntil('form', 'fieldset').each(function() {
+                var $this = $(this);
+                check.disabled = $this.prop('disabled') && ($element.closest($this.children('label:first-of-type')).length == 0);
+            });
+        }
+        if (check.disabled) {
+            $element.trigger('valid');
+            return true;
+        }
+
         if (Support.inputtypes[type]) {
             check.valid = element.validity.valid;
             check.message = element.validationMessage;


### PR DESCRIPTION
Currently validatr does not conform to the HTML5 for validation of form fields when some of those fields are disabled. See this section of the HTML5 specification:

http://www.w3.org/html/wg/drafts/html/master/forms.html#enabling-and-disabling-form-controls:-the-disabled-attribute

This pull request adds code to ensure that disabled elements are not checked for validity, allowing the form to be submitted.
