### PR TITLE
Error message offset for bottom position

### DIFF
--- a/src/js/validatr.js
+++ b/src/js/validatr.js
@@ -915,7 +915,7 @@
             }
 
             if (location === 'bottom') {
-                error.offset({top: offset.top + error.outerHeight()});
+                error.offset({top: offset.top + $target.outerHeight()});
             }
         } else if (filters.leftright.test(location)) {
             error.offset({top: (offset.top + $target.outerHeight() / 2) - (error.outerHeight() / 2)});


### PR DESCRIPTION
Error message's offset for bottom position was not correct it was adding message's height to target's offset however target's height should be added to target's offset to get message at right position.
