### PR TITLE
docs: Fix simple typo, seperated -> separated

### DIFF
--- a/libs/jquery/jquery.js
+++ b/libs/jquery/jquery.js
@@ -2338,7 +2338,7 @@ jQuery.fn.extend({
 					classNames = value.split( rspace );
 
 				while ( (className = classNames[ i++ ]) ) {
-					// check each className given, space seperated list
+					// check each className given, space separated list
 					state = isBool ? state : !self.hasClass( className );
 					self[ state ? "addClass" : "removeClass" ]( className );
 				}


### PR DESCRIPTION
There is a small typo in libs/jquery/jquery.js.

Closes #28

